### PR TITLE
Fixed incorrect scaling in CircleStimulus

### DIFF
--- a/stytra/stimulation/stimuli/visual.py
+++ b/stytra/stimulation/stimuli/visual.py
@@ -491,7 +491,10 @@ class CircleStimulus(VisualStimulus, DynamicStimulus):
     def paint(self, p, w, h):
         super().paint(p, w, h)
 
-        mm_px = self._experiment.calibrator.params["mm_px"]
+        if self._experiment.calibrator is not None:
+            mm_px = self._experiment.calibrator.params["mm_px"]
+        else:
+            mm_px = 1
 
         # draw the background
         p.setPen(Qt.NoPen)
@@ -501,8 +504,8 @@ class CircleStimulus(VisualStimulus, DynamicStimulus):
 
         # draw the circle
         p.setBrush(QBrush(QColor(*self.circle_color)))
-        p.drawEllipse(QPointF(self.x*mm_px, self.y*mm_px),
-                      self.radius*mm_px, self.radius*mm_px)
+        p.drawEllipse(QPointF(self.x / mm_px, self.y / mm_px),
+                      self.radius / mm_px, self.radius / mm_px)
 
 
 # Stimuli which need to be implemented


### PR DESCRIPTION
Simple fix to make sure that scaling works correctly in `CircleStimulus`.
It might be worthwhile to make the retrieval of the `mm_px` value happen in a common place (like the parent's `paint` or a method of its own), since other classes might want this value anyway.