### PR TITLE
Fixed inconsistent behavior on calibration

### DIFF
--- a/stytra/gui/monitor_control.py
+++ b/stytra/gui/monitor_control.py
@@ -148,7 +148,8 @@ class ProjectorAndCalibrationWidget(QWidget):
             self.button_calibrate.clicked.connect(self.calibrate)
             self.layout_calibrate.addWidget(self.button_calibrate)
 
-        self.label_calibrate = QLabel("size of calib. pattern in mm")
+        self.label_calibrate = QLabel(self.calibrator.length_to_measure)
+        self.label_calibrate.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         self.layout_calibrate.addWidget(self.button_show_calib)
         self.layout_calibrate.addWidget(self.label_calibrate)
         self.calibrator_len_spin = ParameterSpinBox(

--- a/stytra/stimulation/stimulus_display.py
+++ b/stytra/stimulation/stimulus_display.py
@@ -82,6 +82,8 @@ class StimulusDisplayWindow(QDialog, HasPyQtGraphParams):
     def set_dims(self):
         """ """
         self.widget_display.setGeometry(*(self.params["pos"] + self.params["size"]))
+        self.widget_display.calibrator.set_pixel_scale(*self.params["size"])
+        self.widget_display.calibrator.set_physical_scale()
 
 
 # TODO why here paintEvent draws the stimulus and display_stimulus update


### PR DESCRIPTION
This is a bugfix for inconsistent behavior of the data on the GUI and the experiment.
__Step to reproduce__: set the physical size of the experiment without bringing up the calibration interface. Bringing up the interface won't even fix this completely, as you need to change the spinbox at least once with the interface open.

The fix adds a different method to calibrator instances `set_pixel_scale`, that allows the ROI interface to set pixel sizes without rendering the calibrator. The ROI interface also calls the `set_physical_scale` to insure that the final ratio of pixel to mm is always consistent.