### PR TITLE
Fixed queue kwargs bug in call to FramerateQueueAccumulator.

### DIFF
--- a/stytra/experiments/camera_recording_experiment.py
+++ b/stytra/experiments/camera_recording_experiment.py
@@ -31,8 +31,15 @@ class VideoRecordingExperiment(CameraVisualExperiment):
         self.frame_dispatcher.start()
 
         # Create and connect framerate accumulator:
-        self.acc_tracking_framerate = FramerateQueueAccumulator(self, self.frame_dispatcher.framerate_queue, name="tracking",
-                                                                goal_framerate=kwargs["camera"].get("min_framerate", None))
+        self.acc_tracking_framerate = FramerateQueueAccumulator(
+            self,
+            queue=self.frame_dispatcher.framerate_queue,
+            name="tracking",
+            goal_framerate=kwargs["camera"].get(
+                "min_framerate", None
+            ),
+        )
+        
         self.gui_timer.timeout.connect(self.acc_tracking_framerate.update_list)
 
         # self.filename_queue = Queue()
@@ -50,7 +57,6 @@ class VideoRecordingExperiment(CameraVisualExperiment):
         self.video_writer.reset_signal.set()
         super().start_protocol()
 
-
     def end_protocol(self, save=True):
         self.saving_evt.clear()
 
@@ -61,16 +67,3 @@ class VideoRecordingExperiment(CameraVisualExperiment):
         self.video_writer.join()
         print("closed")
         super().wrap_up(*args, **kwargs)
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/stytra/hardware/video/__init__.py
+++ b/stytra/hardware/video/__init__.py
@@ -28,7 +28,7 @@ class VideoSource(FrameProcess):
     """Abstract class for a process that generates frames, being it a camera
     or a file source. A maximum size of the memory used by the process can be
     set.
-    
+
     **Input Queues:**
 
     self.control_queue :
@@ -77,7 +77,7 @@ class CameraSource(VideoSource):
     """Process for controlling a camera.
 
     Cameras currently implemented:
-    
+
     ======== ===========================================
     Ximea    Add some info
     Avt      Add some info
@@ -265,9 +265,14 @@ class VideoFileSource(VideoSource):
     def run(self):
         if self.state is None:
             self.state = VideoControlParameters()
-        if self.source_file.endswith("h5"):
+        if self.source_file.endswith("h5") or self.source_file.endswith("hdf5"):
             framedata = dd.io.load(self.source_file)
-            frames = framedata["video"]
+            
+            if isinstance(framedata, np.ndarray):
+                frames = framedata
+            else:
+                frames = framedata["video"]
+
             i_frame = self.offset
             prt = None
             while not self.kill_event.is_set():


### PR DESCRIPTION
Stytra fails when trying to record using a camera as the FramerateQueueAccumulator ´queue´ argument needs to be passed as a keyword argument.
