### PR TITLE
add Zero ROT mode support for all MQ013xG-ON models

### DIFF
--- a/stytra/hardware/video/cameras/ximea.py
+++ b/stytra/hardware/video/cameras/ximea.py
@@ -38,9 +38,9 @@ class XimeaCamera(Camera):
 
         self.im = xiapi.Image()
 
-        # If camera supports hardware downsampling (MQ013MG-ON does,
+        # If camera supports hardware downsampling (MQ013xG-ON does,
         # MQ003MG-CM does not):
-        if self.cam.get_device_name() == b"MQ013MG-ON":
+        if self.cam.get_device_name() in [b"MQ013MG-ON", b"MQ013RG-ON", b"MQ013CG-ON"]:
             self.cam.set_sensor_feature_selector("XI_SENSOR_FEATURE_ZEROROT_ENABLE")
             self.cam.set_sensor_feature_value(1)
 


### PR DESCRIPTION
A tiny change that is maybe useful to somebody out there: I noticed stytra wasn't enabling Zero ROT mode for my Ximea camera (MQ013RG-ON) and so not performing at maximum frame rate. I added a check for all the Ximea cameras this would apply to (that I know of), which is the MQ013xG-ON line.

Thanks for this beautiful package!