### PR TITLE
Clean-up Experiment dependencies inside Stimulus 

### DIFF
--- a/stytra/stimulation/__init__.py
+++ b/stytra/stimulation/__init__.py
@@ -1,5 +1,6 @@
 import datetime
 from copy import deepcopy
+import warnings
 
 from PyQt5.QtCore import pyqtSignal, QTimer, QObject
 from stytra.stimulation.stimuli import Pause, DynamicStimulus
@@ -112,7 +113,12 @@ class ProtocolRunner(QObject):
 
         # pass experiment to stimuli for calibrator and asset folders:
         for stimulus in self.stimuli:
-            stimulus.initialise_external(self.experiment, self.experiment.calibrator)
+            try:
+                stimulus.initialise_external(self.experiment, self.experiment.calibrator)
+            except TypeError:
+                stimulus.initialise_external(self.experiment)
+                warnings.warn("Warning: 'initialise_external' will require a calibrator input from the new update!", FutureWarning)
+                warnings.warn("Warning: 'initialise_external' will require a calibrator input from the new update!", DeprecationWarning)
 
         if self.dynamic_log is None:
             self.dynamic_log = DynamicLog(self.stimuli, experiment=self.experiment)

--- a/stytra/stimulation/__init__.py
+++ b/stytra/stimulation/__init__.py
@@ -112,7 +112,7 @@ class ProtocolRunner(QObject):
 
         # pass experiment to stimuli for calibrator and asset folders:
         for stimulus in self.stimuli:
-            stimulus.initialise_external(self.experiment)
+            stimulus.initialise_external(self.experiment, self.experiment.calibrator)
 
         if self.dynamic_log is None:
             self.dynamic_log = DynamicLog(self.stimuli, experiment=self.experiment)

--- a/stytra/stimulation/stimuli/conditional.py
+++ b/stytra/stimulation/stimuli/conditional.py
@@ -36,9 +36,9 @@ class PauseOutsideStimulus(DynamicStimulus):
             state.update(self.active.get_dynamic_state())
         return state
 
-    def initialise_external(self, experiment):
-        super().initialise_external(experiment)
-        self.active.initialise_external(experiment)
+    def initialise_external(self, experiment, calibrator):
+        super().initialise_external(experiment, calibrator)
+        self.active.initialise_external(experiment, calibrator)
 
     def get_state(self):
         state = super().get_state()
@@ -50,7 +50,7 @@ class PauseOutsideStimulus(DynamicStimulus):
         self.active.start()
 
     def check_condition(self):
-        y, x, theta = self._experiment.estimator.get_position()
+        y, x, theta = self._experiment.estimator.get_position()#! TOFIX: Remove
         return not np.isnan(y)
 
     def update(self):
@@ -157,10 +157,10 @@ class ConditionalWrapper(DynamicStimulus):
             state.update(self._stim_on.get_dynamic_state())
         return state
 
-    def initialise_external(self, experiment):
-        super().initialise_external(experiment)
-        self._stim_on.initialise_external(experiment)
-        self._stim_off.initialise_external(experiment)
+    def initialise_external(self, experiment, calibrator):
+        super().initialise_external(experiment, calibrator)
+        self._stim_on.initialise_external(experiment, calibrator)
+        self._stim_off.initialise_external(experiment, calibrator)
 
     def get_state(self):
         state = super().get_state()
@@ -270,8 +270,8 @@ class CenteringWrapper(SingleConditionalWrapper):
         self.yc = 240
 
     def check_condition_on(self):
-        y, x, theta = self._experiment.estimator.get_position()
-        scale = self._experiment.calibrator.mm_px ** 2
+        y, x, theta = self._experiment.estimator.get_position()#! TOFIX: Remove
+        scale = self._calibrator.mm_px ** 2 
         return (
             x > 0 and ((x - self.xc) ** 2 + (y - self.yc) ** 2) <= self.margin / scale
         )
@@ -323,15 +323,15 @@ class TwoRadiusCenteringWrapper(ConditionalWrapper):
         self.yc = 240
 
     def check_condition_on(self):
-        y, x, theta = self._experiment.estimator.get_position()
-        scale = self._experiment.calibrator.mm_px ** 2
+        y, x, theta = self._experiment.estimator.get_position() #! TOFIX: Remove
+        scale = self._calibrator.mm_px ** 2
         return (not np.isnan(x)) and (
             (x - self.xc) ** 2 + (y - self.yc) ** 2 <= self.margin_in / scale
         )
 
     def check_condition_off(self):
-        y, x, theta = self._experiment.estimator.get_position()
-        scale = self._experiment.calibrator.mm_px ** 2
+        y, x, theta = self._experiment.estimator.get_position() #! TOFIX: Remove
+        scale = self._calibrator.mm_px ** 2
         return np.isnan(x) or (
             (x - self.xc) ** 2 + (y - self.yc) ** 2 > self.margin_out / scale
         )

--- a/stytra/stimulation/stimuli/external.py
+++ b/stytra/stimulation/stimuli/external.py
@@ -42,7 +42,7 @@ class PybPulseStimulus(Stimulus):
         pulse_dur_str = str(pulse_dur_ms).zfill(3)
         self.mex = str("shock" + amp_dac + pulse_dur_str)
 
-    def initialise_external(self, experiment):
+    def initialise_external(self, experiment, calibrator):
         """
 
         Parameters

--- a/stytra/stimulation/stimuli/generic_stimuli.py
+++ b/stytra/stimulation/stimuli/generic_stimuli.py
@@ -65,7 +65,8 @@ class Stimulus:
         self._started = None
         self._elapsed = 0.0  # time from the beginning of the stimulus
         self.name = "undefined"
-        self._experiment = None
+        self._experiment = None  #! TOFIX: Remove
+        self._calibrator = None
         self.real_time_start = None
         self.real_time_stop = None
 
@@ -111,7 +112,7 @@ class Stimulus:
         """
         pass
 
-    def initialise_external(self, experiment):
+    def initialise_external(self, experiment, calibrator = None):
         """ Make a reference to the Experiment class inside the Stimulus.
         This is required to access from inside the Stimulus class to the
         Calibrator, the Pyboard, the asset directories with movies or the motor
@@ -130,7 +131,8 @@ class Stimulus:
             None
 
         """
-        self._experiment = experiment
+        self._experiment = experiment #! TOFIX: Remove
+        self._calibrator = calibrator
 
 
 class DynamicStimulus(Stimulus):
@@ -251,7 +253,7 @@ class TriggerStimulus(DynamicStimulus):
 
     def update(self):
         # If trigger is set, make it end:
-        if self._experiment.trigger.start_event.is_set():
+        if self._experiment.trigger.start_event.is_set(): #! TOFIX: Remove ?
             self.duration = self._elapsed
 
 
@@ -289,10 +291,10 @@ class CombinerStimulus(DynamicStimulus):
             s.update()
             s._elapsed = self._elapsed
 
-    def initialise_external(self, experiment):
-        super().initialise_external(experiment)
+    def initialise_external(self, experiment, calibrator):
+        super().initialise_external(experiment, calibrator)
         for s in self._stim_list:
-            s.initialise_external(experiment)
+            s.initialise_external(experiment, calibrator)
 
     @property
     def dynamic_parameter_names(self):

--- a/stytra/stimulation/stimuli/generic_stimuli.py
+++ b/stytra/stimulation/stimuli/generic_stimuli.py
@@ -1,5 +1,6 @@
 import numpy as np
 import datetime
+import warnings
 
 
 class Stimulus:
@@ -112,7 +113,7 @@ class Stimulus:
         """
         pass
 
-    def initialise_external(self, experiment, calibrator = None):
+    def initialise_external(self, experiment, calibrator = -999):
         """ Make a reference to the Experiment class inside the Stimulus.
         This is required to access from inside the Stimulus class to the
         Calibrator, the Pyboard, the asset directories with movies or the motor
@@ -131,8 +132,18 @@ class Stimulus:
             None
 
         """
+        
+        if calibrator == -999:
+            self._calibrator = self._experiment.calibrator
+            warnings.warn("Warning: 'initialise_external' will require a calibrator input from the new update!", FutureWarning)
+            warnings.warn("Warning: 'initialise_external' will require a calibrator input from the new update!", DeprecationWarning)
+        else:
+            self._calibrator = calibrator
+            
+            
         self._experiment = experiment #! TOFIX: Remove
-        self._calibrator = calibrator
+        
+    
 
 
 class DynamicStimulus(Stimulus):

--- a/stytra/stimulation/stimuli/kinematograms.py
+++ b/stytra/stimulation/stimuli/kinematograms.py
@@ -75,8 +75,8 @@ class DotDisplay(VisualStimulus, InterpolatedStimulus):
         -------
         number of dots to display and the displacement amount in pixel coordinates
         """
-        if self._experiment.calibrator is not None:
-            mm_px = self._experiment.calibrator.mm_px
+        if self._calibrator is not None:
+            mm_px = self._calibrator.mm_px  
         else:
             mm_px = 1
 

--- a/stytra/stimulation/stimuli/visual.py
+++ b/stytra/stimulation/stimuli/visual.py
@@ -206,7 +206,7 @@ class VideoStimulus(VisualStimulus, DynamicStimulus):
 
     def initialise_external(self, *args, **kwargs):
         super().initialise_external(*args, **kwargs)
-        self._video_seq = pims.Video(self._experiment.asset_dir + "/" + self.video_path)
+        self._video_seq = pims.Video(self._experiment.asset_dir + "/" + self.video_path) #! TOFIX: Remove
 
         self._current_frame = self._video_seq.get_frame(self.i_frame)
         try:
@@ -313,8 +313,8 @@ class BackgroundStimulus(PositionStimulus):
         return range(x_start, x_end + 1), range(y_start, y_end + 1)
 
     def paint(self, p, w, h):
-        if self._experiment.calibrator is not None:
-            mm_px = self._experiment.calibrator.mm_px
+        if self._calibrator is not None: 
+            mm_px = self._calibrator.mm_px
         else:
             mm_px = 1
 
@@ -396,8 +396,8 @@ class BaseSeamlessImageStimulus():
                 self.background_name = "array {}x{}".format(*self._background.shape)
         self._qbackground = None
 
-    def initialise_external(self, experiment):
-        super().initialise_external(experiment)
+    def initialise_external(self, experiment, calibrator):
+        super().initialise_external(experiment, calibrator)
 
         # Get background image from folder:
         if isinstance(self._background, str):
@@ -468,7 +468,7 @@ class GratingStimulus(BackgroundStimulus):
     def create_pattern(self):
         l = max(
             2,
-            int(self.grating_period / (max(self._experiment.calibrator.mm_px, 0.0001))),
+            int(self.grating_period / (max(self._calibrator.mm_px, 0.0001))),
         )
         if self.wave_shape == "square":
             self._pattern = np.ones((l, 3), np.uint8) * self.color_1
@@ -483,8 +483,8 @@ class GratingStimulus(BackgroundStimulus):
                 + (1 - w[:, None]) * np.array(self.color_2)[None, :]
             ).astype(np.uint8)
 
-    def initialise_external(self, experiment):
-        super().initialise_external(experiment)
+    def initialise_external(self, experiment, calibrator):
+        super().initialise_external(experiment, calibrator)
         self.create_pattern()
         # Get background image from folder:
         self._qbackground = qimage2ndarray.array2qimage(self._pattern[None, :, :])
@@ -532,7 +532,7 @@ class PaintGratingStimulus(BackgroundStimulus):
         #TODO what does this thing define?
         """
         return (
-            int(self.grating_period / (max(self._experiment.calibrator.mm_px, 0.0001))),
+            int(self.grating_period / (max(self._calibrator.mm_px, 0.0001))),
             self.barheight,
         )
 
@@ -547,7 +547,7 @@ class PaintGratingStimulus(BackgroundStimulus):
             point.y(),
             int(
                 self.grating_period
-                / (2 * max(self._experiment.calibrator.mm_px, 0.0001))
+                / (2 * max(self._calibrator.mm_px, 0.0001))
             ),
             self.barheight,
         )
@@ -654,7 +654,7 @@ class RadialSineStimulus(VisualStimulus):
 
     def paint(self, p, w, h):
         x, y = (
-            (np.arange(d) - d / 2) * self._experiment.calibrator.mm_px for d in (w, h)
+            (np.arange(d) - d / 2) * self._calibrator.mm_px for d in (w, h)
         )
         self.image = np.round(
             np.sin(
@@ -751,8 +751,8 @@ class WindmillStimulus(CenteredBackgroundStimulus):
         self._pattern = W * self.color_1 + (1 - W) * self.color_2
         self._qbackground = qimage2ndarray.array2qimage(self._pattern)
 
-    def initialise_external(self, experiment):
-        super().initialise_external(experiment)
+    def initialise_external(self, experiment, calibrator):
+        super().initialise_external(experiment, calibrator)
         self.create_pattern()
 
     def draw_block(self, p, point, w, h):
@@ -933,8 +933,8 @@ class CalibratedCircleStimulus(VisualStimulus, DynamicStimulus):
     def paint(self, p, w, h):
         super().paint(p, w, h)
 
-        if self._experiment.calibrator is not None:
-            mm_px = self._experiment.calibrator.mm_px
+        if self._calibrator is not None:
+            mm_px = self._calibrator.mm_px
         else:
             mm_px = 1
 


### PR DESCRIPTION
With this PR the protocol runner passes the calibrator object from the method `initialise_external()`.
To avoid problems with existing custom stimuli which may have rewritten the method I added two warnings.

### More specifically I expect two cases to throw errors:

1. if the protocol runner calls a custom stimulus where the `initialise_external()` function doesn't accept the `calibrator` input.
2. if the function  `initialise_external()` is used without passing the  `calibrator` input.

### To fix 1:
in the protocol runner there's a `try{} except{}` block that tries to feed the calibrator object to the stimulus initialise_external() function.  If this doesn't work then the protocol runner raises a warning and then calls the function without the `calibrator` input.

### To fix 2:
the `initialise_external()` has an **optional** argument `calibrator` which has default value -999, if the default value is detected then the `self._calibrator` is initialized with the `self._experiment` and a warning is given to the user.
else the `self._calibrator` is initialized with the `calibrator` input
 