### PR TITLE
Optimise the Prefilter

### DIFF
--- a/stytra/tracking/preprocessing.py
+++ b/stytra/tracking/preprocessing.py
@@ -43,7 +43,9 @@ class Prefilter(ImageToImageNode):
         if color_invert:
             im = 255 - im
         if clip > 0:
-            im = np.maximum(im, clip) - clip
+            # Maxval only exists because it is required,
+            # since we use cv2.THRES_TOZERO, we do not set things to maxval.
+            im = cv2.threshold(src=im, thresh=clip, maxval=255, type=cv2.THRESH_TOZERO)[1]
 
         if self.set_diagnostic == "filtered":
             self.diagnostic_image = im

--- a/stytra/tracking/preprocessing.py
+++ b/stytra/tracking/preprocessing.py
@@ -45,7 +45,9 @@ class Prefilter(ImageToImageNode):
         if clip > 0:
             # Maxval only exists because it is required,
             # since we use cv2.THRES_TOZERO, we do not set things to maxval.
-            im = cv2.threshold(src=im, thresh=clip, maxval=255, type=cv2.THRESH_TOZERO)[1]
+            im = cv2.threshold(src=im, thresh=clip, maxval=255, type=cv2.THRESH_TOZERO)[
+                1
+            ]
 
         if self.set_diagnostic == "filtered":
             self.diagnostic_image = im


### PR DESCRIPTION
Pretty minor PR. The OpenCV `threshold` function should be about 2-3 times more efficient than the line that it replaces. This can especially become noticeable when not downsampling the image.