### PR TITLE
Updated black version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ Sphinx
 
 pytest
 pytest-cov
-black==22.1.0
+black==22.3.0
 
 pytest-qt
 pytest-forked


### PR DESCRIPTION
There was an update in one of the dependencies of black which broke one import (see [here](https://github.com/psf/black/issues/2976) )

This has been fixed in the new release, which I updated in this PR