### PR TITLE
Fix #78

### DIFF
--- a/stytra/hardware/video/write.py
+++ b/stytra/hardware/video/write.py
@@ -252,7 +252,9 @@ class StreamingVideoWriter(VideoWriter):
         self._container = None
         self._stream = None
 
-        self.__container_filename = self.__generate_filename(self.CONST_FALLBACK_FILENAME)
+        self.__container_filename = self.__generate_filename(
+            self.CONST_FALLBACK_FILENAME
+        )
 
     def __generate_filename(self, filename: str) -> str:
         """
@@ -303,7 +305,9 @@ class StreamingVideoWriter(VideoWriter):
         super()._reset()
         self._container = None
         self._stream = None
-        self.__container_filename = self.__generate_filename(self.CONST_FALLBACK_FILENAME)
+        self.__container_filename = self.__generate_filename(
+            self.CONST_FALLBACK_FILENAME
+        )
 
     def _complete(self, filename: str) -> None:
         """

--- a/stytra/hardware/video/write.py
+++ b/stytra/hardware/video/write.py
@@ -252,7 +252,7 @@ class StreamingVideoWriter(VideoWriter):
         self._container = None
         self._stream = None
 
-        self.__container_filename = self.CONST_FALLBACK_FILENAME
+        self.__container_filename = self.__generate_filename(self.CONST_FALLBACK_FILENAME)
 
     def __generate_filename(self, filename: str) -> str:
         """
@@ -303,7 +303,7 @@ class StreamingVideoWriter(VideoWriter):
         super()._reset()
         self._container = None
         self._stream = None
-        self.__container_filename = self.CONST_FALLBACK_FILENAME
+        self.__container_filename = self.__generate_filename(self.CONST_FALLBACK_FILENAME)
 
     def _complete(self, filename: str) -> None:
         """


### PR DESCRIPTION
The default values set for the video file were not passed through the filename generator (to add things like the filename extension, which is the reason for the error mentioned in #78). In this PR I add the filename generator calls.