### PR TITLE
Fix progress indicator in offline video processing

### DIFF
--- a/stytra/experiments/tracking_experiments.py
+++ b/stytra/experiments/tracking_experiments.py
@@ -161,7 +161,8 @@ class CameraVisualExperiment(VisualExperiment):
         for q in [self.camera.frame_queue]:
             q.clear()
 
-        self.camera.join()
+        if self.camera.is_alive():
+            self.camera.join()
 
     def _setup_frame_dispatcher(self, recording_event: Event = None) -> DispatchProcess:
         """

--- a/stytra/hardware/video/__init__.py
+++ b/stytra/hardware/video/__init__.py
@@ -331,8 +331,11 @@ class VideoFileSource(VideoSource):
             container.streams.video[0].thread_count = 1
 
             prt = None
-            while self.loop:
+            while not self.kill_event.is_set():
                 for framedata in container.decode(video=0):
+                    if self.kill_event.is_set():
+                        break
+
                     messages = []
                     if self.paused:
                         frame = self.old_frame

--- a/stytra/offline/track_video.py
+++ b/stytra/offline/track_video.py
@@ -75,8 +75,6 @@ class OfflineToolbar(QToolBar):
             l = reader.count_frames()
         else:
             l = reader.get_length()
-        if not (0 < l < 100000):
-            l = 1
         self.diag_track.prog_track.setMaximum(l)
         self.diag_track.lbl_status.setText("Tracking to " + output_name)
 

--- a/stytra/offline/track_video.py
+++ b/stytra/offline/track_video.py
@@ -65,13 +65,16 @@ class OfflineToolbar(QToolBar):
         fileformat = self.cmb_fmt.currentText()
 
         self.exp.camera.kill_event.set()
-        reader = imageio.get_reader(str(self.input_path))
+        reader = imageio.get_reader(str(self.input_path), 'ffmpeg')
         data = []
         self.exp.window_main.stream_plot.toggle_freeze()
 
         output_name = str(self.output_path) + "." + fileformat
         self.diag_track.show()
-        l = reader.count_frames()
+        if (hasattr(reader, 'count_frames')):
+            l = reader.count_frames()
+        else:
+            l = reader.get_length()
         if not (0 < l < 100000):
             l = 1
         self.diag_track.prog_track.setMaximum(l)

--- a/stytra/offline/track_video.py
+++ b/stytra/offline/track_video.py
@@ -65,13 +65,13 @@ class OfflineToolbar(QToolBar):
         fileformat = self.cmb_fmt.currentText()
 
         self.exp.camera.kill_event.set()
-        reader = imageio.get_reader(str(self.input_path), 'ffmpeg')
+        reader = imageio.get_reader(str(self.input_path), "ffmpeg")
         data = []
         self.exp.window_main.stream_plot.toggle_freeze()
 
         output_name = str(self.output_path) + "." + fileformat
         self.diag_track.show()
-        if (hasattr(reader, 'count_frames')):
+        if hasattr(reader, "count_frames"):
             l = reader.count_frames()
         else:
             l = reader.get_length()

--- a/stytra/offline/track_video.py
+++ b/stytra/offline/track_video.py
@@ -71,7 +71,7 @@ class OfflineToolbar(QToolBar):
 
         output_name = str(self.output_path) + "." + fileformat
         self.diag_track.show()
-        l = reader.get_length()
+        l = reader.count_frames()
         if not (0 < l < 100000):
             l = 1
         self.diag_track.prog_track.setMaximum(l)


### PR DESCRIPTION
Currently the progress indicator immediately jumps to 100% (see issue #30).

There seem to be multiple methods in the `imageio` library to get the number of frames:
+ `len(reader)`
+ `reader.get_length()`
+ `reader.frame_count()`

`len(reader)` and `reader.get_length()` should technically be the same but give different outputs. `reader.get_length()` returns `inf` for a stream, while `len(reader)` returns `sys.maxsize()`. `reader.frame_count()` relies on `ffmpeg` to extract the number of frames.

`reader.frame_count()` does not seem completely accurate, as I had videos stop at 96% progress, but it seems to be the closest estimate of the 3 methods and is an improvement to the current behaviour.